### PR TITLE
RIDER-1438 KMultiplatformBleAdapter 적용

### DIFF
--- a/ios/BleClient.m
+++ b/ios/BleClient.m
@@ -7,7 +7,7 @@
 //
 
 #import "BleClient.h"
-@import MultiplatformBleAdapter;
+@import KMultiplatformBleAdapter;
 
 @interface BleModule () <BleClientManagerDelegate>
 @property(nonatomic) BleClientManager* manager;

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,5 +6,5 @@ target 'BleClient' do
   use_frameworks!
 
   # Pods for BleClient
-  pod 'MultiplatformBleAdapter', '~> 0.1.9'
+  pod 'KMultiplatformBleAdapter'
 end

--- a/react-native-ble-plx.podspec
+++ b/react-native-ble-plx.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.summary      = "React Native Bluetooth Low Energy library"
 
   s.authors      = { "Przemysław Lenart" => "przemek.lenart@gmail.com" }
-  s.homepage     = "https://github.com/Polidea/react-native-ble-plx#readme"
+  s.homepage     = "https://github.com/team-olulo/react-native-ble-plx"
   s.license      = "Apache License 2.0"
   s.platform     = :ios, "8.0"
 
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DMULTIPLATFORM_BLE_ADAPTER'
 
   s.dependency 'React-Core'
-  s.dependency 'MultiplatformBleAdapter'#, :git => 'https://github.com/below/MultiPlatformBleAdapter', :tag => '0.1.9'
+  s.dependency 'KMultiplatformBleAdapter'
 end


### PR DESCRIPTION
XCode13 오류에 대응하기 위해 
MultiplatformBleAdapter대신 KMultiplatformBleAdapter를 적용
MultiplatformBleAdapter가 0.1.8까지만 Pods에 배포되어있다.